### PR TITLE
Implement eip-1186, eth_getProof

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -28,6 +28,15 @@ func ToHex(b []byte) string {
 	return "0x" + hex
 }
 
+// ToHexArray creates a array of hex-string based on []byte
+func ToHexArray(b [][]byte) []string {
+	r := make([]string, len(b))
+	for i := range b {
+		r[i] = ToHex(b[i])
+	}
+	return r
+}
+
 func FromHex(s string) []byte {
 	if len(s) > 1 {
 		if s[0:2] == "0x" || s[0:2] == "0X" {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -98,16 +98,19 @@ func (b *EthApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumb
 	return b.eth.blockchain.GetBlockByNumber(uint64(blockNr)), nil
 }
 
-func (b *EthApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
+func (b *EthApiBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
 	// Pending state is only known by the miner
-	if blockNr == rpc.PendingBlockNumber {
+	if number == rpc.PendingBlockNumber {
 		block, state := b.eth.miner.Pending()
 		return state, block.Header(), nil
 	}
 	// Otherwise resolve the block number and return its state
-	header, err := b.HeaderByNumber(ctx, blockNr)
-	if header == nil || err != nil {
+	header, err := b.HeaderByNumber(ctx, number)
+	if err != nil {
 		return nil, nil, err
+	}
+	if header == nil {
+		return nil, nil, errors.New("header not found")
 	}
 	stateDb, err := b.eth.BlockChain().StateAt(header.Root)
 	return stateDb, header, err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -526,6 +526,72 @@ func (s *PublicBlockChainAPI) GetBalance(ctx context.Context, address common.Add
 	return b, state.Error()
 }
 
+// Result structs for GetProof
+type AccountResult struct {
+	Address      common.Address  `json:"address"`
+	AccountProof []string        `json:"accountProof"`
+	Balance      *hexutil.Big    `json:"balance"`
+	CodeHash     common.Hash     `json:"codeHash"`
+	Nonce        hexutil.Uint64  `json:"nonce"`
+	StorageHash  common.Hash     `json:"storageHash"`
+	StorageProof []StorageResult `json:"storageProof"`
+}
+type StorageResult struct {
+	Key   string       `json:"key"`
+	Value *hexutil.Big `json:"value"`
+	Proof []string     `json:"proof"`
+}
+
+// GetProof returns the Merkle-proof for a given account and optionally some storage keys.
+func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNr rpc.BlockNumber) (*AccountResult, error) {
+	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNr)
+	if state == nil || err != nil {
+		return nil, err
+	}
+
+	storageTrie := state.StorageTrie(address)
+	storageHash := types.EmptyRootHash
+	codeHash := state.GetCodeHash(address)
+	storageProof := make([]StorageResult, len(storageKeys))
+
+	// if we have a storageTrie, (which means the account exists), we can update the storagehash
+	if storageTrie != nil {
+		storageHash = storageTrie.Hash()
+	} else {
+		// no storageTrie means the account does not exist, so the codeHash is the hash of an empty bytearray.
+		codeHash = crypto.Keccak256Hash(nil)
+	}
+
+	// create the proof for the storageKeys
+	for i, key := range storageKeys {
+		if storageTrie != nil {
+			proof, storageError := state.GetStorageProof(address, common.HexToHash(key))
+			if storageError != nil {
+				return nil, storageError
+			}
+			storageProof[i] = StorageResult{key, (*hexutil.Big)(state.GetState(address, common.HexToHash(key)).Big()), common.ToHexArray(proof)}
+		} else {
+			storageProof[i] = StorageResult{key, &hexutil.Big{}, []string{}}
+		}
+	}
+
+	// create the accountProof
+	accountProof, proofErr := state.GetProof(address)
+	if proofErr != nil {
+		return nil, proofErr
+	}
+
+	return &AccountResult{
+		Address:      address,
+		AccountProof: common.ToHexArray(accountProof),
+		Balance:      (*hexutil.Big)(state.GetBalance(address)),
+		CodeHash:     codeHash,
+		Nonce:        hexutil.Uint64(state.GetNonce(address)),
+		StorageHash:  storageHash,
+		StorageProof: storageProof,
+	}, state.Error()
+}
+
 // GetBlockByNumber returns the requested block. When blockNr is -1 the chain head is returned. When fullTx is true all
 // transactions in the block are returned in full detail, otherwise only the transaction hash is returned.
 func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {


### PR DESCRIPTION
#473
References:
- [EIP-1186 eth_getProof #17737](https://github.com/ethereum/go-ethereum/pull/17737)
- [core/state: simplify proof methods #17965](https://github.com/ethereum/go-ethereum/pull/17965)

Flowchart summary:
[General](https://mermaid.live/view#pako:eNqNVdty2jAQ_RWNMtMnyIBtSPBDO9wvCQ4BmqQ1mY6ABTwxEpXlJJTw75UlDHKbduKHHVt7ds9e5R2esTlgFy9C9jJbES7QuDGhSD5VfziooyH8jCESLgKx-rEEMeCMLR5RPv8Z1XZ3JAzmRAAaEE7WIIBHe22sZS3BvXXpc4J7Q3V_CCLmFDU5Z_zRxNxpRMNvg0AjIX02augT6gCZQ4rUsqG4mzsFQtVnEoRkGsKXA3FTufOYZDMPvkH0hlq-NJIZqhxQGyhwIgJGM_5byn9bBVKdzVhMBWoQQR5Ndcc_WMMRowtjgrq-PJtBFMmEGCdLQFewjTJkbQXs-S0Qs9XRVZcu2AHW04CiCqdGQkJnkFVZSuWxvxS2UtRle1GHRKus0jkUWsdl6LXsKNSVf7MBqtuBxjxICa6U9vpUgz7wpxAyJdCyq5D9nVkA1FxvxDbtV__UnoGsF2wIBzl00YbRKOXrH3vqHUvaJLJg0l2GzlN0XjGNW5MakXtFjbAy6cvhi48ISyPsU3YpzEzPszXM2fUZ13mlGXnOKSUvc5RkMDDj7RXljPesRNiJULAUcm1-aDlQR7d-kyZbqwNKB-pW6YZ-i_E1Eag3uvH-rONQQUbpFkptHIpMAaN4uuRks9IbKueCzsOALrUyeerKxThlMRc5ecZK_TVlSILIJ7eIiQM6f5dSj5nsnF7K6OT1zk9vBLkhsvkG4b2fdNewMnQP_j8W_USuvKuY7w2f6uDh_WjFVg56FS2CMHTPFpVFLhKcPYF7Ztv24T3_EszFyrU2r6bN4GAznX7cZpTaLKYftqmnsU3_b4NzeA2yicFc3v67xMMEixWsYYJd-Ton_GmCJ3QvcSQWbLSlM-wKHkMOcxYvV9hdkDCSX_Em-QU0AiLbuE4hG0K_M2Z-YneHX7FrOeelknNRsgrlslUo2I6Tw1vs5ouFQuHcurQqF6WKZdlFp7zP4V_KhX1eLFkVq-w4pULhwrbsy_1vnagAZQ)

Notice:
Pending block tag support, when client call method, miner returns block with falsy value (block number 0x1400224ca20). Latest version of Geth should prevent calling with a “pending” block tag.
