### PR TITLE
Trace blocks to file

### DIFF
--- a/cmd/tomo/main.go
+++ b/cmd/tomo/main.go
@@ -128,6 +128,7 @@ var (
 		utils.RollbackFlag,
 		utils.TomoSlaveModeFlag,
 		utils.ReexecFlag,
+		utils.TraceOutdirFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -584,6 +584,10 @@ var (
 		Usage: "Reexec blocks",
 		Value: 256,
 	}
+	TraceOutdirFlag = DirectoryFlag{
+		Name:  "trace-outdir",
+		Usage: "Data directory for the trace output",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1171,6 +1175,14 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 			os.Mkdir(common.StoreRewardFolder, os.ModePerm)
 		}
 	}
+	if ctx.GlobalIsSet(TraceOutdirFlag.Name) {
+		absPath, _ := filepath.Abs(ctx.GlobalString(TraceOutdirFlag.Name))
+		common.StoreTraceFolder = absPath
+		if _, err := os.Stat(common.StoreTraceFolder); os.IsNotExist(err) {
+			os.Mkdir(common.StoreTraceFolder, os.ModePerm)
+		}
+	}
+	log.Info("Trace output datadir", "path", common.StoreTraceFolder)
 	// Override any default configs for hard coded networks.
 	switch {
 	case ctx.GlobalBool(TestnetFlag.Name):

--- a/common/constants.go
+++ b/common/constants.go
@@ -45,6 +45,7 @@ var (
 	StoreRewardFolder string
 	RollbackHash      Hash
 	LimitTimeFinality = uint64(30) // limit in 30 block
+	StoreTraceFolder  string
 
 	BasePrice               = big.NewInt(1000000000000000000)                // 1
 	BaseLendingInterest     = big.NewInt(100000000)                          // 1e8

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -719,7 +719,6 @@ func (api *PrivateDebugAPI) StandardTraceBlocksToFile(ctx context.Context, numbe
 	if common.StoreTraceFolder == "" {
 		return nil, errors.New("trace output directory not set")
 	}
-
 	var allDumps []string
 	for _, number := range numbers {
 		file, err := api.standardTraceBlockToFile(ctx, number, config)
@@ -737,7 +736,6 @@ func (api *PrivateDebugAPI) StandardTraceBlocksToFile(ctx context.Context, numbe
 // to the caller..
 func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, number rpc.BlockNumber, config *TraceConfig) (string, error) {
 	var block *types.Block
-
 	switch number {
 	case rpc.PendingBlockNumber:
 		block = api.eth.miner.PendingBlock()
@@ -750,13 +748,10 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, number
 	if block == nil {
 		return "", fmt.Errorf("block #%d not found", number)
 	}
-
 	var results, err = api.traceBlock(ctx, block, config)
-
 	if err != nil {
 		return "", fmt.Errorf("failed to trace block: %v", err)
 	}
-
 	path := filepath.Join(common.StoreTraceFolder, fmt.Sprintf("block_%d.json", block.NumberU64()))
 	log.Info("Writing block trace to file", "file", path)
 	f, err := os.Create(path)
@@ -764,14 +759,11 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, number
 		return "", fmt.Errorf("failed to create trace file: %v", err)
 	}
 	defer f.Close()
-
 	encoder := json.NewEncoder(f)
 	encoder.SetIndent("", "  ") // Pretty print
 	if err := encoder.Encode(results); err != nil {
 		return "", fmt.Errorf("failed to encode trace result: %v", err)
 	}
-
 	log.Info("Wrote block trace", "file", path)
-
 	return path, nil
 }

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -19,10 +19,13 @@ package eth
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"time"
@@ -710,4 +713,65 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 	}
 	statedb.DeleteSuicides()
 	return nil, vm.Context{}, nil, fmt.Errorf("tx index %d out of range for block %x", txIndex, blockHash)
+}
+
+func (api *PrivateDebugAPI) StandardTraceBlocksToFile(ctx context.Context, numbers []rpc.BlockNumber, config *TraceConfig) ([]string, error) {
+	if common.StoreTraceFolder == "" {
+		return nil, errors.New("trace output directory not set")
+	}
+
+	var allDumps []string
+	for _, number := range numbers {
+		file, err := api.standardTraceBlockToFile(ctx, number, config)
+		if err != nil {
+			log.Warn("Trace failed", "block", number, "err", err)
+			continue
+		}
+		allDumps = append(allDumps, file)
+	}
+	return allDumps, nil
+}
+
+// StandardTraceBlockToFile dumps the structured logs created during the
+// execution of EVM to the local file system and returns a list of files
+// to the caller..
+func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, number rpc.BlockNumber, config *TraceConfig) (string, error) {
+	var block *types.Block
+
+	switch number {
+	case rpc.PendingBlockNumber:
+		block = api.eth.miner.PendingBlock()
+	case rpc.LatestBlockNumber:
+		block = api.eth.blockchain.CurrentBlock()
+	default:
+		block = api.eth.blockchain.GetBlockByNumber(uint64(number))
+	}
+	// Trace the block if it was found
+	if block == nil {
+		return "", fmt.Errorf("block #%d not found", number)
+	}
+
+	var results, err = api.traceBlock(ctx, block, config)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to trace block: %v", err)
+	}
+
+	path := filepath.Join(common.StoreTraceFolder, fmt.Sprintf("block_%d.json", block.NumberU64()))
+	log.Info("Writing block trace to file", "file", path)
+	f, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to create trace file: %v", err)
+	}
+	defer f.Close()
+
+	encoder := json.NewEncoder(f)
+	encoder.SetIndent("", "  ") // Pretty print
+	if err := encoder.Encode(results); err != nil {
+		return "", fmt.Errorf("failed to encode trace result: %v", err)
+	}
+
+	log.Info("Wrote block trace", "file", path)
+
+	return path, nil
 }

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -379,6 +379,12 @@ web3._extend({
 			inputFormatter: [null, null]
 		}),
 		new web3._extend.Method({
+			name: 'standardTraceBlocksToFile',
+			call: 'debug_standardTraceBlocksToFile',
+			params: 2,
+			inputFormatter: [null, null]
+		}),
+		new web3._extend.Method({
 			name: 'traceBlockByNumber',
 			call: 'debug_traceBlockByNumber',
 			params: 2,


### PR DESCRIPTION
This pull request introduces a new feature for tracing Ethereum blocks and saving the trace output to files. The changes include adding a new command-line flag, updating configurations, and implementing methods to handle block tracing and file output. Below are the most important changes grouped by theme:

### Command-line Flag and Configuration Updates:
* Added a new `trace-outdir` flag (`utils.TraceOutdirFlag`) to specify the directory for saving trace outputs. This flag is integrated into the CLI in `cmd/tomo/main.go` and defined in `cmd/utils/flags.go`. [[1]](diffhunk://#diff-4868ac43372589c101e52eb558c138e568149d626bdaf61611f4481082ceb1ccR131) [[2]](diffhunk://#diff-7aa83061ca1c69a8ab9203da49a7581bad6e7cc80ecb96582e7fb09c0b8f6534R587-R590)
* Updated the `SetEthConfig` function in `cmd/utils/flags.go` to handle the `trace-outdir` flag, including setting the directory path, creating the folder if it doesn’t exist, and logging the output path.
* Added a new global variable `StoreTraceFolder` in `common/constants.go` to store the directory path for trace outputs.

### Block Tracing Feature:
* Implemented a new method `StandardTraceBlocksToFile` in `eth/api_tracer.go` to trace multiple blocks and save the outputs as JSON files in the specified directory.
* Added a helper method `standardTraceBlockToFile` in `eth/api_tracer.go` to handle tracing for individual blocks, encoding the results as JSON, and writing them to files.

### Web3 API Extension:
* Added a new Web3 method `standardTraceBlocksToFile` in `internal/web3ext/web3ext.go` to expose the block tracing functionality via the Web3 API.