### PR TITLE
feat: add caching mechanism for closest finalized block to optimize f…

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -875,15 +875,23 @@ func (bc *BlockChain) GetBlocksHashCache(number uint64) []common.Hash {
 // AreTwoBlockSamePath check if two blocks are same path
 // Assume block 1 is ahead block 2 so we need to check parentHash
 func (bc *BlockChain) AreTwoBlockSamePath(bh1 common.Hash, bh2 common.Hash) bool {
-	bl1 := bc.GetBlockByHash(bh1)
-	bl2 := bc.GetBlockByHash(bh2)
-	toBlockLevel := bl2.Number().Uint64()
+	h1 := bc.GetHeaderByHash(bh1)
+	h2 := bc.GetHeaderByHash(bh2)
+	if h1 == nil || h2 == nil {
+		return false
+	}
+	toLevel := h2.Number.Uint64()
+	hash1 := bh1
 
-	for bl1.Number().Uint64() > toBlockLevel {
-		bl1 = bc.GetBlockByHash(bl1.ParentHash())
+	for h1.Number.Uint64() > toLevel {
+		hash1 = h1.ParentHash
+		h1 = bc.GetHeaderByHash(hash1)
+		if h1 == nil {
+			return false
+		}
 	}
 
-	return (bl1.Hash() == bl2.Hash())
+	return hash1 == bh2
 }
 
 // GetUnclesInChain retrieves all the uncles from a given block backwards until

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tomochain/tomochain/tomox/tradingstate"
@@ -495,12 +496,14 @@ func (s *PrivateAccountAPI) SignAndSendTransaction(ctx context.Context, args Sen
 // PublicBlockChainAPI provides an API to access the Ethereum blockchain.
 // It offers only methods that operate on public data that is freely available to anyone.
 type PublicBlockChainAPI struct {
-	b Backend
+	b                  Backend
+	closestFinalizedMu sync.RWMutex
+	closestFinalized   *types.Block
 }
 
 // NewPublicBlockChainAPI creates a new Ethereum blockchain API.
 func NewPublicBlockChainAPI(b Backend) *PublicBlockChainAPI {
-	return &PublicBlockChainAPI{b}
+	return &PublicBlockChainAPI{b: b}
 }
 
 // BlockNumber returns the block number of the chain head.
@@ -694,7 +697,7 @@ func (s *PublicBlockChainAPI) GetBlockFinalityByHash(ctx context.Context, blockH
 
 	// Try strict 100% finality check first via closest finalized block.
 	// Pass queried block number so the scan stops early if it drops below.
-	closest := s.findClosestFinalizedBlock(ctx, block.NumberU64())
+	closest := s.findClosestFinalizedBlockCached(ctx, block.NumberU64())
 	if closest != nil {
 		if block.NumberU64() <= closest.NumberU64() && s.b.AreTwoBlockSamePath(closest.Hash(), block.Hash()) {
 			return 100, nil
@@ -722,7 +725,7 @@ func (s *PublicBlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, bloc
 
 	// Try strict 100% finality check first via closest finalized block.
 	// Pass queried block number so the scan stops early if it drops below.
-	closest := s.findClosestFinalizedBlock(ctx, block.NumberU64())
+	closest := s.findClosestFinalizedBlockCached(ctx, block.NumberU64())
 	if closest != nil {
 		if block.NumberU64() <= closest.NumberU64() && s.b.AreTwoBlockSamePath(closest.Hash(), block.Hash()) {
 			return 100, nil
@@ -1350,11 +1353,41 @@ func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx
 	return fields, nil
 }
 
+// findClosestFinalizedBlockCached uses a head-aware cache to avoid repeating
+// expensive backward scans for every finality RPC call.
+func (s *PublicBlockChainAPI) findClosestFinalizedBlockCached(ctx context.Context, targetNumber uint64) *types.Block {
+	s.closestFinalizedMu.RLock()
+	cachedClosest := s.closestFinalized
+	s.closestFinalizedMu.RUnlock()
+
+	// Once finalized, a block stays finalized. Return immediately if cached
+	// result already covers the target.
+	if cachedClosest != nil && targetNumber <= cachedClosest.NumberU64() {
+		return cachedClosest
+	}
+
+	// Scan backward from head down to targetNumber.
+	closest := s.findClosestFinalizedBlock(ctx, targetNumber)
+
+	// Update cache only if we found a better (higher) finalized block.
+	if closest != nil {
+		s.closestFinalizedMu.Lock()
+		if s.closestFinalized == nil || closest.NumberU64() > s.closestFinalized.NumberU64() {
+			s.closestFinalized = closest
+		}
+		s.closestFinalizedMu.Unlock()
+	}
+
+	if closest != nil && targetNumber <= closest.NumberU64() {
+		return closest
+	}
+	return nil
+}
+
 // findClosestFinalizedBlock scans backward from the current head to find the nearest
 // block with 100% finality (all masternodes have signed).
 // targetNumber is the queried block number: scanning stops early if it drops below this
 // value, since no result below the target can make the target finalized.
-// Pass 0 to scan without early stopping (used by FinalityBlockClosest).
 func (s *PublicBlockChainAPI) findClosestFinalizedBlock(ctx context.Context, targetNumber uint64) *types.Block {
 	head := s.b.CurrentBlock()
 	if head == nil {
@@ -1362,44 +1395,70 @@ func (s *PublicBlockChainAPI) findClosestFinalizedBlock(ctx context.Context, tar
 	}
 
 	headNumber := head.NumberU64()
+
+	engine, ok := s.b.GetEngine().(*posv.Posv)
+	if !ok {
+		return nil
+	}
+	epochSize := s.b.ChainConfig().Posv.Epoch
+
 	scanStartBlockNumber, step := headNumber, uint64(1)
 	if chainConfig := s.b.ChainConfig(); chainConfig != nil && chainConfig.IsTIPSigning(new(big.Int).SetUint64(headNumber)) {
 		step = uint64(common.MergeSignRange)
 		scanStartBlockNumber = headNumber - (headNumber % step)
 	}
 
-	checkFinality := func(number uint64) (*types.Block, bool) {
-		if number < targetNumber {
-			return nil, false
-		}
+	// Cache the epoch checkpoint block across iterations to avoid redundant
+	// DB reads — blocks within the same epoch share the same checkpoint.
+	var cachedCheckpointNum uint64
+	var cachedCheckpointBlock *types.Block
+
+	checkFinality := func(number uint64) *types.Block {
 		candidate, err := s.b.BlockByNumber(ctx, rpc.BlockNumber(number))
 		if err != nil || candidate == nil {
-			return nil, false
-		}
-		masternodes, err := s.GetMasternodes(ctx, candidate)
-		if err != nil || len(masternodes) == 0 {
-			return nil, false
-		}
-		finality, err := s.findFinalityOfBlock(ctx, candidate, masternodes)
-		if err == nil && finality == 100 {
-			return candidate, true
-		}
-		return nil, false
-	}
-
-	for number := scanStartBlockNumber; number > 0; {
-		if number < targetNumber {
 			return nil
 		}
 
-		if candidate, ok := checkFinality(number); ok {
+		// Compute the epoch checkpoint (mirrors GetMasternodes logic).
+		prevBlockNumber := number + (common.MergeSignRange - (number % common.MergeSignRange))
+		if prevBlockNumber >= headNumber || !s.b.ChainConfig().IsTIP2019(candidate.Number()) {
+			prevBlockNumber = number
+		}
+		checkpointNum := prevBlockNumber - (prevBlockNumber % epochSize)
+
+		// Reuse cached checkpoint block if within the same epoch.
+		if checkpointNum != cachedCheckpointNum || cachedCheckpointBlock == nil {
+			cachedCheckpointBlock, _ = s.b.BlockByNumber(ctx, rpc.BlockNumber(checkpointNum))
+			cachedCheckpointNum = checkpointNum
+		}
+
+		if cachedCheckpointBlock == nil {
+			return nil
+		}
+
+		masternodes := engine.GetMasternodesFromCheckpointHeader(cachedCheckpointBlock.Header(), number, epochSize)
+		if len(masternodes) == 0 {
+			return nil
+		}
+
+		finality, err := s.findFinalityOfBlock(ctx, candidate, masternodes)
+		if err == nil && finality == 100 {
 			return candidate
 		}
-		if number <= step {
+		return nil
+	}
+
+	for number := scanStartBlockNumber; number >= targetNumber; {
+		if block := checkFinality(number); block != nil {
+			return block
+		}
+
+		if number < step {
 			break
 		}
 		number -= step
 	}
+
 	return nil
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1366,8 +1366,13 @@ func (s *PublicBlockChainAPI) findClosestFinalizedBlockCached(ctx context.Contex
 		return cachedClosest
 	}
 
-	// Scan backward from head down to targetNumber.
-	closest := s.findClosestFinalizedBlock(ctx, targetNumber)
+	// Scan a bounded range near head — not all the way down to targetNumber.
+	// If found, it covers all older blocks too.
+	// Use a timeout (like TraceBlockByNumber) to guarantee the RPC never blocks.
+	scanCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	closest := s.findClosestFinalizedBlock(scanCtx, targetNumber)
 
 	// Update cache only if we found a better (higher) finalized block.
 	if closest != nil {
@@ -1386,8 +1391,14 @@ func (s *PublicBlockChainAPI) findClosestFinalizedBlockCached(ctx context.Contex
 
 // findClosestFinalizedBlock scans backward from the current head to find the nearest
 // block with 100% finality (all masternodes have signed).
-// targetNumber is the queried block number: scanning stops early if it drops below this
-// value, since no result below the target can make the target finalized.
+//
+// The caller provides a context with a timeout (e.g. 3 s) so the scan never
+// blocks indefinitely — similar to TraceBlockByNumber's defaultTraceTimeout.
+//
+// The scan range is split into parallel chunks processed by multiple goroutines.
+// Each goroutine scans its chunk from high to low.  As soon as any goroutine
+// finds a finalized block, the remaining work is cancelled via context so that
+// lower chunks (which can only produce inferior results) stop early.
 func (s *PublicBlockChainAPI) findClosestFinalizedBlock(ctx context.Context, targetNumber uint64) *types.Block {
 	head := s.b.CurrentBlock()
 	if head == nil {
@@ -1408,55 +1419,124 @@ func (s *PublicBlockChainAPI) findClosestFinalizedBlock(ctx context.Context, tar
 		scanStartBlockNumber = headNumber - (headNumber % step)
 	}
 
-	// Cache the epoch checkpoint block across iterations to avoid redundant
-	// DB reads — blocks within the same epoch share the same checkpoint.
-	var cachedCheckpointNum uint64
-	var cachedCheckpointBlock *types.Block
-
-	checkFinality := func(number uint64) *types.Block {
-		candidate, err := s.b.BlockByNumber(ctx, rpc.BlockNumber(number))
-		if err != nil || candidate == nil {
-			return nil
-		}
-
-		// Compute the epoch checkpoint (mirrors GetMasternodes logic).
-		prevBlockNumber := number + (common.MergeSignRange - (number % common.MergeSignRange))
-		if prevBlockNumber >= headNumber || !s.b.ChainConfig().IsTIP2019(candidate.Number()) {
-			prevBlockNumber = number
-		}
-		checkpointNum := prevBlockNumber - (prevBlockNumber % epochSize)
-
-		// Reuse cached checkpoint block if within the same epoch.
-		if checkpointNum != cachedCheckpointNum || cachedCheckpointBlock == nil {
-			cachedCheckpointBlock, _ = s.b.BlockByNumber(ctx, rpc.BlockNumber(checkpointNum))
-			cachedCheckpointNum = checkpointNum
-		}
-
-		if cachedCheckpointBlock == nil {
-			return nil
-		}
-
-		masternodes := engine.GetMasternodesFromCheckpointHeader(cachedCheckpointBlock.Header(), number, epochSize)
-		if len(masternodes) == 0 {
-			return nil
-		}
-
-		finality, err := s.findFinalityOfBlock(ctx, candidate, masternodes)
-		if err == nil && finality == 100 {
-			return candidate
-		}
+	if scanStartBlockNumber < targetNumber {
 		return nil
 	}
 
-	for number := scanStartBlockNumber; number >= targetNumber; {
-		if block := checkFinality(number); block != nil {
-			return block
+	// Step-aligned positions from scanStartBlockNumber down to targetNumber.
+	// The 3-second context timeout from the caller bounds wall-clock time.
+	totalPositions := (scanStartBlockNumber-targetNumber)/step + 1
+
+	// Number of parallel workers.  Keep bounded to avoid excessive goroutine
+	// overhead on small ranges.
+	const maxWorkers = 4
+	numWorkers := maxWorkers
+	if totalPositions < uint64(numWorkers) {
+		numWorkers = int(totalPositions)
+	}
+	if numWorkers <= 0 {
+		return nil
+	}
+
+	positionsPerWorker := totalPositions / uint64(numWorkers)
+	// Note: when totalPositions is not evenly divisible by numWorkers, the
+	// last worker absorbs the remainder (not computed from positionsPerWorker).
+
+	type result struct {
+		block *types.Block
+	}
+
+	scanCtx, scanCancel := context.WithCancel(ctx)
+	defer scanCancel()
+
+	results := make([]chan result, numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		results[i] = make(chan result, 1)
+	}
+
+	for i := 0; i < numWorkers; i++ {
+		// Chunk boundaries: worker 0 gets the highest blocks (closest to head).
+		chunkHi := scanStartBlockNumber - uint64(i)*positionsPerWorker*step
+		var chunkLo uint64
+		if i == numWorkers-1 {
+			// Last worker absorbs the remainder from integer division.
+			remainingPositions := totalPositions - uint64(i)*positionsPerWorker
+			chunkLo = chunkHi - (remainingPositions-1)*step
+		} else {
+			chunkLo = chunkHi - (positionsPerWorker-1)*step
 		}
 
-		if number < step {
-			break
+		ch := results[i]
+		go func(hi, lo uint64) {
+			// Each goroutine has its own checkpoint cache to avoid races.
+			var localCachedCheckpointNum uint64
+			var localCachedCheckpointBlock *types.Block
+
+			checkFinality := func(number uint64) *types.Block {
+				// Respect cancellation from a higher-priority chunk.
+				select {
+				case <-scanCtx.Done():
+					return nil
+				default:
+				}
+
+				candidate, err := s.b.BlockByNumber(scanCtx, rpc.BlockNumber(number))
+				if err != nil || candidate == nil {
+					return nil
+				}
+
+				prevBlockNumber := number + (common.MergeSignRange - (number % common.MergeSignRange))
+				if prevBlockNumber >= headNumber || !s.b.ChainConfig().IsTIP2019(candidate.Number()) {
+					prevBlockNumber = number
+				}
+				checkpointNum := prevBlockNumber - (prevBlockNumber % epochSize)
+
+				if checkpointNum != localCachedCheckpointNum || localCachedCheckpointBlock == nil {
+					localCachedCheckpointBlock, _ = s.b.BlockByNumber(scanCtx, rpc.BlockNumber(checkpointNum))
+					localCachedCheckpointNum = checkpointNum
+				}
+
+				if localCachedCheckpointBlock == nil {
+					return nil
+				}
+
+				masternodes := engine.GetMasternodesFromCheckpointHeader(localCachedCheckpointBlock.Header(), number, epochSize)
+				if len(masternodes) == 0 {
+					return nil
+				}
+
+				finality, err := s.findFinalityOfBlock(scanCtx, candidate, masternodes)
+				if err == nil && finality == 100 {
+					return candidate
+				}
+				return nil
+			}
+
+			for number := hi; number >= lo; {
+				if blk := checkFinality(number); blk != nil {
+					ch <- result{block: blk}
+					return
+				}
+
+				if number < step {
+					break
+				}
+				number -= step
+			}
+			ch <- result{block: nil}
+		}(chunkHi, chunkLo)
+	}
+
+	// Collect results in chunk order (highest blocks first).
+	// The first worker to return a finalized block gives us the best possible
+	// result for its chunk.  Workers for higher chunks are checked first, so
+	// the first non-nil result is the overall highest finalized block.
+	for i := 0; i < numWorkers; i++ {
+		r := <-results[i]
+		if r.block != nil {
+			scanCancel() // cancel lower-priority workers
+			return r.block
 		}
-		number -= step
 	}
 
 	return nil

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1473,12 +1473,6 @@ func (s *PublicBlockChainAPI) findClosestFinalizedBlock(ctx context.Context, tar
 			var localCachedCheckpointBlock *types.Block
 
 			checkFinality := func(number uint64) *types.Block {
-				// Respect cancellation from a higher-priority chunk.
-				select {
-				case <-scanCtx.Done():
-					return nil
-				default:
-				}
 
 				candidate, err := s.b.BlockByNumber(scanCtx, rpc.BlockNumber(number))
 				if err != nil || candidate == nil {
@@ -1513,6 +1507,14 @@ func (s *PublicBlockChainAPI) findClosestFinalizedBlock(ctx context.Context, tar
 			}
 
 			for number := hi; number >= lo; {
+				// Exit the loop immediately when context is cancelled.
+				select {
+				case <-scanCtx.Done():
+					ch <- result{block: nil}
+					return
+				default:
+				}
+
 				if blk := checkFinality(number); blk != nil {
 					ch <- result{block: blk}
 					return


### PR DESCRIPTION
## Issue: 
- Calling `eth_getBlockFinalityByHash` or `eth_getBlockFinalityByNumber` on mainnet consistently returned HTTP 504 Gateway Timeout. The RPC call never completed within the gateway's timeout window.

## Root Cause
- The original implementation had no caching. Every call to `GetBlockFinalityByHash` triggered a full backward scan from the chain head. On mainnet with millions of blocks and ~2s block time, this scan could walk thousands of blocks before finding a finalized one — well beyond the RPC gateway's timeout threshold

## Solution
- Added `findClosestFinalizedBlockCached` with a monotonic closestFinalized cache on PublicBlockChainAPI, the cached result is valid indefinitely. Subsequent calls for any block ≤ the cached finalized height return immediately without scanning.  

- Split all blocks into chunks for searching, and process them using multiple workers. If any block received  from the channel that is not nil, all workers should stop immediately.
- Increase limit time to avoid timeout : `	scanCtx, cancel := context.WithTimeout(ctx, 3*time.Second)`
- Refactor `AreTwoBlockSamePath` to fetch only the block header instead of the entire block.

- Update `closestFinalized` if `closest.NumberU64() is greater than s.closestFinalized.NumberU64()`

- Cache `cachedCheckpointNum` and `cachedCheckpointBlock` in `findClosestFinalizedBlock` to avoid redundant DB reads when multiple scan iterations fall within the same epoch checkpoint