### PR TITLE
Feature/finality api

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -875,15 +875,23 @@ func (bc *BlockChain) GetBlocksHashCache(number uint64) []common.Hash {
 // AreTwoBlockSamePath check if two blocks are same path
 // Assume block 1 is ahead block 2 so we need to check parentHash
 func (bc *BlockChain) AreTwoBlockSamePath(bh1 common.Hash, bh2 common.Hash) bool {
-	bl1 := bc.GetBlockByHash(bh1)
-	bl2 := bc.GetBlockByHash(bh2)
-	toBlockLevel := bl2.Number().Uint64()
+	h1 := bc.GetHeaderByHash(bh1)
+	h2 := bc.GetHeaderByHash(bh2)
+	if h1 == nil || h2 == nil {
+		return false
+	}
+	toLevel := h2.Number.Uint64()
+	hash1 := bh1
 
-	for bl1.Number().Uint64() > toBlockLevel {
-		bl1 = bc.GetBlockByHash(bl1.ParentHash())
+	for h1.Number.Uint64() > toLevel {
+		hash1 = h1.ParentHash
+		h1 = bc.GetHeaderByHash(hash1)
+		if h1 == nil {
+			return false
+		}
 	}
 
-	return (bl1.Hash() == bl2.Hash())
+	return hash1 == bh2
 }
 
 // GetUnclesInChain retrieves all the uncles from a given block backwards until

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -692,26 +692,44 @@ func (s *PublicBlockChainAPI) GetBlockFinalityByHash(ctx context.Context, blockH
 		return 100, nil
 	}
 
-	// Try strict 100% finality check first via closest finalized block.
-	// Pass queried block number so the scan stops early if it drops below.
-	closest := s.findClosestFinalizedBlock(ctx, block.NumberU64())
-	if closest != nil {
-		if block.NumberU64() <= closest.NumberU64() && s.b.AreTwoBlockSamePath(closest.Hash(), block.Hash()) {
+	var finalityLegacy uint
+	masternodes, err := s.GetMasternodes(ctx, block)
+	if err != nil {
+		log.Error("Failed to get masternodes", "number", block.NumberU64(), "hash", block.Hash(), "err", err)
+	} else if len(masternodes) == 0 {
+		log.Error("Empty masternodes", "number", block.NumberU64(), "hash", block.Hash())
+	} else {
+		// Masternodes available — compute legacy finality.
+		finalityLegacy, err = s.findFinalityOfBlock(ctx, block, masternodes)
+		if err != nil {
+			// Legacy finality calculation failed; fall through to findClosestFinalizedBlock.
+			log.Error("Failed to find legacy finality of block", "number", block.NumberU64(), "hash", block.Hash(), "err", err)
+		} else if finalityLegacy == 100 {
 			return 100, nil
 		}
 	}
 
-	// Fallback to legacy percentage flow.
-	masternodes, err := s.GetMasternodes(ctx, block)
-	if err != nil || len(masternodes) == 0 {
-		log.Error("Failed to get masternodes", "err", err, "len(masternodes)", len(masternodes))
-		return uint(0), err
+	// findClosestFinalizedBlock scans forward from block.NumberU64(), so closest
+	// (if non-nil) is always at a number >= block.NumberU64(); the same-path check
+	// is the only condition that can distinguish canonical from fork blocks here.
+	closest, closestFinality := s.findClosestFinalizedBlock(ctx, block.NumberU64())
+	if closest == nil {
+		// No finalized block found ahead; fall back to the legacy percentage.
+		return finalityLegacy, nil
 	}
-	return s.findFinalityOfBlock(ctx, block, masternodes)
+	if s.b.AreTwoBlockSamePath(closest.Hash(), block.Hash()) {
+		// Block is on the same canonical path as the nearest finalized block.
+		if closestFinality > finalityLegacy {
+			return closestFinality, nil
+		}
+		return finalityLegacy, nil
+	}
+
+	// closest is on a different fork — the queried block has been orphaned.
+	return 0, fmt.Errorf("can not find finality at block %d with hash %s", block.NumberU64(), block.Hash())
 }
 
 func (s *PublicBlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, blockNumber rpc.BlockNumber) (uint, error) {
-
 	block, err := s.b.BlockByNumber(ctx, blockNumber)
 	if err != nil || block == nil {
 		return uint(0), err
@@ -721,22 +739,41 @@ func (s *PublicBlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, bloc
 		return 100, nil
 	}
 
-	// Try strict 100% finality check first via closest finalized block.
-	// Pass queried block number so the scan stops early if it drops below.
-	closest := s.findClosestFinalizedBlock(ctx, block.NumberU64())
-	if closest != nil {
-		if block.NumberU64() <= closest.NumberU64() && s.b.AreTwoBlockSamePath(closest.Hash(), block.Hash()) {
+	var finalityLegacy uint
+	masternodes, err := s.GetMasternodes(ctx, block)
+	if err != nil {
+		log.Error("Failed to get masternodes", "number", block.NumberU64(), "hash", block.Hash(), "err", err)
+	} else if len(masternodes) == 0 {
+		log.Error("Empty masternodes", "number", block.NumberU64(), "hash", block.Hash())
+	} else {
+		// Masternodes available — compute legacy finality.
+		finalityLegacy, err = s.findFinalityOfBlock(ctx, block, masternodes)
+		if err != nil {
+			// Legacy finality calculation failed; fall through to findClosestFinalizedBlock.
+			log.Error("Failed to find legacy finality of block", "number", block.NumberU64(), "hash", block.Hash(), "err", err)
+		} else if finalityLegacy == 100 {
 			return 100, nil
 		}
 	}
 
-	// Fallback to legacy percentage flow.
-	masternodes, err := s.GetMasternodes(ctx, block)
-	if err != nil || len(masternodes) == 0 {
-		log.Error("Failed to get masternodes", "err", err, "len(masternodes)", len(masternodes))
-		return uint(0), err
+	// findClosestFinalizedBlock scans forward from block.NumberU64(), so closest
+	// (if non-nil) is always at a number >= block.NumberU64(); the same-path check
+	// is the only condition that can distinguish canonical from fork blocks here.
+	closest, closestFinality := s.findClosestFinalizedBlock(ctx, block.NumberU64())
+	if closest == nil {
+		// No finalized block found ahead; fall back to the legacy percentage.
+		return finalityLegacy, nil
 	}
-	return s.findFinalityOfBlock(ctx, block, masternodes)
+	if s.b.AreTwoBlockSamePath(closest.Hash(), block.Hash()) {
+		// Block is on the same canonical path as the nearest finalized block.
+		if closestFinality > finalityLegacy {
+			return closestFinality, nil
+		}
+		return finalityLegacy, nil
+	}
+
+	// closest is on a different fork — the queried block has been orphaned.
+	return 0, fmt.Errorf("can not find finality at block %d with hash %s", block.NumberU64(), block.Hash())
 }
 
 // GetMasternodes returns masternodes set at the starting block of epoch of the given block
@@ -1351,34 +1388,47 @@ func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx
 	return fields, nil
 }
 
-// findClosestFinalizedBlock scans backward from the current head to find the nearest
-// block with 100% finality (all masternodes have signed).
-// targetNumber is the queried block number: scanning stops early if it drops below this
-// value, since no result below the target can make the target finalized.
-// Pass 0 to scan without early stopping (used by FinalityBlockClosest).
-func (s *PublicBlockChainAPI) findClosestFinalizedBlock(ctx context.Context, targetNumber uint64) *types.Block {
+// findClosestFinalizedBlock scans forward from targetNumber to the current chain
+// head looking for the block with the highest finality percentage.
+//
+// When the TIPSigning fork is active, only MergeSignRange checkpoint blocks are
+// checked (rounded up from targetNumber); otherwise every block is checked.
+//
+// Returns the best block found and its finality percentage (0–100).
+// Returns (nil, 0) when no candidate could be evaluated (e.g. no chain head).
+func (s *PublicBlockChainAPI) findClosestFinalizedBlock(ctx context.Context, targetNumber uint64) (*types.Block, uint) {
 	head := s.b.CurrentBlock()
 	if head == nil {
-		return nil
+		return nil, 0
 	}
 
 	headNumber := head.NumberU64()
-	scanStartBlockNumber, step := targetNumber, uint64(1)
+
+	// Determine scan step and start position.
+	// Under TIPSigning, signatures are aggregated at MergeSignRange checkpoints,
+	// so only those block numbers carry meaningful finality data.
+	step := uint64(1)
+	scanStart := targetNumber
 	if chainConfig := s.b.ChainConfig(); chainConfig != nil && chainConfig.IsTIPSigning(new(big.Int).SetUint64(headNumber)) {
 		step = uint64(common.MergeSignRange)
-		// Round up to the nearest checkpoint >= targetNumber.
-		remainder := targetNumber % step
-		if remainder == 0 {
-			scanStartBlockNumber = targetNumber
-		} else {
-			scanStartBlockNumber = targetNumber + (step - remainder)
+		// Round up to the first checkpoint >= targetNumber.
+		if rem := targetNumber % step; rem != 0 {
+			scanStart = targetNumber + (step - rem)
 		}
 	}
 
-	checkFinality := func(number uint64) (*types.Block, bool) {
-		if number > headNumber {
-			return nil, false
-		}
+	// Track the highest-finality block seen so far.
+	// Used as the fallback result when no block reaches 100%.
+	var (
+		bestFinality uint
+		bestBlock    *types.Block
+	)
+
+	// evalBlock computes the finality of the block at number and updates the
+	// running best. Returns (block, true) when 100% finality is confirmed so
+	// the caller can stop early; returns (nil, false) when the block should be
+	// skipped (fetch error, no masternodes, or finality error).
+	evalBlock := func(number uint64) (*types.Block, bool) {
 		candidate, err := s.b.BlockByNumber(ctx, rpc.BlockNumber(number))
 		if err != nil || candidate == nil {
 			return nil, false
@@ -1388,20 +1438,30 @@ func (s *PublicBlockChainAPI) findClosestFinalizedBlock(ctx context.Context, tar
 			return nil, false
 		}
 		finality, err := s.findFinalityOfBlock(ctx, candidate, masternodes)
-		if err == nil && finality == 100 {
+		if err != nil {
+			return nil, false
+		}
+		if finality > bestFinality {
+			bestFinality = finality
+			bestBlock = candidate
+		}
+		if finality == 100 {
 			return candidate, true
 		}
 		return nil, false
 	}
 
-	for number := scanStartBlockNumber; number <= headNumber; {
-
-		if candidate, ok := checkFinality(number); ok {
-			return candidate
+	for number := scanStart; number <= headNumber; number += step {
+		if candidate, found := evalBlock(number); found {
+			return candidate, 100
 		}
-		number += step
 	}
-	return nil
+
+	// No block reached 100%; return the best partial result if any.
+	if bestFinality > 0 && bestBlock != nil {
+		return bestBlock, bestFinality
+	}
+	return nil, 0
 }
 
 // findNearestSignedBlock finds the nearest checkpoint from input block

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -687,46 +687,7 @@ func (s *PublicBlockChainAPI) GetBlockFinalityByHash(ctx context.Context, blockH
 	if err != nil || block == nil {
 		return uint(0), err
 	}
-
-	if block.NumberU64() == 0 {
-		return 100, nil
-	}
-
-	var finalityLegacy uint
-	masternodes, err := s.GetMasternodes(ctx, block)
-	if err != nil {
-		log.Error("Failed to get masternodes", "number", block.NumberU64(), "hash", block.Hash(), "err", err)
-	} else if len(masternodes) == 0 {
-		log.Error("Empty masternodes", "number", block.NumberU64(), "hash", block.Hash())
-	} else {
-		// Masternodes available — compute legacy finality.
-		finalityLegacy, err = s.findFinalityOfBlock(ctx, block, masternodes)
-		if err != nil {
-			// Legacy finality calculation failed; fall through to findClosestFinalizedBlock.
-			log.Error("Failed to find legacy finality of block", "number", block.NumberU64(), "hash", block.Hash(), "err", err)
-		} else if finalityLegacy == 100 {
-			return 100, nil
-		}
-	}
-
-	// findClosestFinalizedBlock scans forward from block.NumberU64(), so closest
-	// (if non-nil) is always at a number >= block.NumberU64(); the same-path check
-	// is the only condition that can distinguish canonical from fork blocks here.
-	closest, closestFinality := s.findClosestFinalizedBlock(ctx, block.NumberU64())
-	if closest == nil {
-		// No finalized block found ahead; fall back to the legacy percentage.
-		return finalityLegacy, nil
-	}
-	if s.b.AreTwoBlockSamePath(closest.Hash(), block.Hash()) {
-		// Block is on the same canonical path as the nearest finalized block.
-		if closestFinality > finalityLegacy {
-			return closestFinality, nil
-		}
-		return finalityLegacy, nil
-	}
-
-	// closest is on a different fork — the queried block has been orphaned.
-	return 0, fmt.Errorf("can not find finality at block %d with hash %s", block.NumberU64(), block.Hash())
+	return s.getBlockFinality(ctx, block)
 }
 
 func (s *PublicBlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, blockNumber rpc.BlockNumber) (uint, error) {
@@ -734,7 +695,14 @@ func (s *PublicBlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, bloc
 	if err != nil || block == nil {
 		return uint(0), err
 	}
+	return s.getBlockFinality(ctx, block)
+}
 
+// getBlockFinality computes the finality percentage for an already-fetched block.
+// It first attempts the legacy per-block finality calculation, then falls back to
+// scanning forward with findClosestFinalizedBlock when the legacy path fails or
+// returns a partial result.
+func (s *PublicBlockChainAPI) getBlockFinality(ctx context.Context, block *types.Block) (uint, error) {
 	if block.NumberU64() == 0 {
 		return 100, nil
 	}
@@ -773,7 +741,7 @@ func (s *PublicBlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, bloc
 	}
 
 	// closest is on a different fork — the queried block has been orphaned.
-	return 0, fmt.Errorf("can not find finality at block %d with hash %s", block.NumberU64(), block.Hash())
+	return finalityLegacy, nil
 }
 
 // GetMasternodes returns masternodes set at the starting block of epoch of the given block

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -691,6 +691,9 @@ func (s *PublicBlockChainAPI) GetBlockFinalityByHash(ctx context.Context, blockH
 	if block.NumberU64() == 0 {
 		return 100, nil
 	}
+	defer func(start time.Time) {
+		log.Info("GetBlockFinalityByNumber", "blockNumber", block.NumberU64(), "elapsed", time.Since(start))
+	}(time.Now())
 
 	// Try strict 100% finality check first via closest finalized block.
 	// Pass queried block number so the scan stops early if it drops below.
@@ -711,6 +714,11 @@ func (s *PublicBlockChainAPI) GetBlockFinalityByHash(ctx context.Context, blockH
 }
 
 func (s *PublicBlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, blockNumber rpc.BlockNumber) (uint, error) {
+
+	defer func(start time.Time) {
+		log.Info("GetBlockFinalityByNumber", "blockNumber", blockNumber, "elapsed", time.Since(start))
+	}(time.Now())
+
 	block, err := s.b.BlockByNumber(ctx, blockNumber)
 	if err != nil || block == nil {
 		return uint(0), err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1370,14 +1370,20 @@ func (s *PublicBlockChainAPI) findClosestFinalizedBlock(ctx context.Context, tar
 	}
 
 	headNumber := head.NumberU64()
-	scanStartBlockNumber, step := headNumber, uint64(1)
+	scanStartBlockNumber, step := targetNumber, uint64(1)
 	if chainConfig := s.b.ChainConfig(); chainConfig != nil && chainConfig.IsTIPSigning(new(big.Int).SetUint64(headNumber)) {
 		step = uint64(common.MergeSignRange)
-		scanStartBlockNumber = headNumber - (headNumber % step)
+		// Round up to the nearest checkpoint >= targetNumber.
+		remainder := targetNumber % step
+		if remainder == 0 {
+			scanStartBlockNumber = targetNumber
+		} else {
+			scanStartBlockNumber = targetNumber + (step - remainder)
+		}
 	}
 
 	checkFinality := func(number uint64) (*types.Block, bool) {
-		if number < targetNumber {
+		if number > headNumber {
 			return nil, false
 		}
 		candidate, err := s.b.BlockByNumber(ctx, rpc.BlockNumber(number))
@@ -1395,18 +1401,12 @@ func (s *PublicBlockChainAPI) findClosestFinalizedBlock(ctx context.Context, tar
 		return nil, false
 	}
 
-	for number := scanStartBlockNumber; number > 0; {
-		if number < targetNumber {
-			return nil
-		}
+	for number := scanStartBlockNumber; number <= headNumber; {
 
 		if candidate, ok := checkFinality(number); ok {
 			return candidate
 		}
-		if number <= step {
-			break
-		}
-		number -= step
+		number += step
 	}
 	return nil
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -691,9 +691,6 @@ func (s *PublicBlockChainAPI) GetBlockFinalityByHash(ctx context.Context, blockH
 	if block.NumberU64() == 0 {
 		return 100, nil
 	}
-	defer func(start time.Time) {
-		log.Info("GetBlockFinalityByNumber", "blockNumber", block.NumberU64(), "elapsed", time.Since(start))
-	}(time.Now())
 
 	// Try strict 100% finality check first via closest finalized block.
 	// Pass queried block number so the scan stops early if it drops below.
@@ -714,10 +711,6 @@ func (s *PublicBlockChainAPI) GetBlockFinalityByHash(ctx context.Context, blockH
 }
 
 func (s *PublicBlockChainAPI) GetBlockFinalityByNumber(ctx context.Context, blockNumber rpc.BlockNumber) (uint, error) {
-
-	defer func(start time.Time) {
-		log.Info("GetBlockFinalityByNumber", "blockNumber", blockNumber, "elapsed", time.Since(start))
-	}(time.Now())
 
 	block, err := s.b.BlockByNumber(ctx, blockNumber)
 	if err != nil || block == nil {


### PR DESCRIPTION
## Issue: 
- Calling `eth_getBlockFinalityByHash` or `eth_getBlockFinalityByNumber` on mainnet consistently returned HTTP 504 Gateway Timeout. The RPC call never completed within the gateway's timeout window.

## Root Cause
- Every call to `GetBlockFinalityByHash` triggered a full backward scan from the chain head. On mainnet with millions of blocks and ~2s block time, this scan could walk thousands of blocks before finding a finalized one — well beyond the RPC gateway's timeout threshold

## Solution
- Updated get block finality flow in `GetBlockFinalityByHash` and `GetBlockFinalityByNumber`:
- Firstly find finality by legacy path: `GetMasternodes` + `findFinalityOfBlock` (percentage finality) and receive `finalityLegacy`
- If cannot find a `100%` finalized anchor (returns `nil` / no match) fallback by using `findClosestFinalizedBlock`
- Find the finalized block closest to the current block with 100% finality:
       - Start from input block.
       - If `IsTIPSigning(headNumber)`:
         - `step = MergeSignRange`
         - Aligned start:
         -  Round up to the nearest checkpoint >= targetNumber.
		remainder := targetNumber % step
		if remainder == 0 {
			scanStartBlockNumber = targetNumber
		} else {
			scanStartBlockNumber = targetNumber + (step - remainder)
		}
      - Else:
        - `step = 1` (per-height scan)
      - Move forward  (`number += step`)
      - Early stop when `number > targetNumber`
      -  Check `if finality > bestFinality {
			bestFinality = finality
			bestBlock = candidate
		}`
      - Return first candidate where finality evaluates to `100%`
      - If `findClosestFinalizedBlock` cannot find a `100%` finalized anchor (returns `nil` / no match), compare `bestFinality` and `finalityLegacy`