### PR TITLE
Enable Pre-Prometheus hard fork

### DIFF
--- a/core/fee_distribution_test.go
+++ b/core/fee_distribution_test.go
@@ -47,7 +47,7 @@ func TestNormalTransactionFeeDistribution(t *testing.T) {
 		minerBalance                 *big.Int
 		senderBalance                *big.Int
 		expectSuccess                bool
-		experientialHardFork         bool
+		prePrometheusHardFork        bool
 		expectedMinerBalanceAfterTx  *big.Int
 		expectedSenderBalanceAfterTx *big.Int
 	}{
@@ -60,7 +60,7 @@ func TestNormalTransactionFeeDistribution(t *testing.T) {
 			minerBalance:                 big.NewInt(0),
 			senderBalance:                big.NewInt(2000000000000000000), // 2 ETH
 			expectSuccess:                true,
-			experientialHardFork:         false,
+			prePrometheusHardFork:        false,
 			expectedMinerBalanceAfterTx:  big.NewInt(21000000000000),     // 0 + (21000 * 1 Gwei)
 			expectedSenderBalanceAfterTx: big.NewInt(999979000000000000), // 2 ETH - 1 ETH - 0.000021 ETH
 		},
@@ -73,12 +73,12 @@ func TestNormalTransactionFeeDistribution(t *testing.T) {
 			minerBalance:                 big.NewInt(0),
 			senderBalance:                big.NewInt(5000000000000000000), // 5 ETH
 			expectSuccess:                true,
-			experientialHardFork:         false,
+			prePrometheusHardFork:        false,
 			expectedMinerBalanceAfterTx:  big.NewInt(2100000000000000),    // 0 + (21000 * 100 Gwei)
 			expectedSenderBalanceAfterTx: big.NewInt(4897900000000000000), // 5 ETH - 0.1 ETH - 0.0021 ETH
 		},
 		{
-			name:                         "After Experimental - Standard ETH transaction fee distribution",
+			name:                         "After PrePrometheus - Standard ETH transaction fee distribution",
 			gasPrice:                     big.NewInt(2000000000), // 2 Gwei
 			gasLimit:                     21000,
 			gasUsed:                      21000,
@@ -86,12 +86,12 @@ func TestNormalTransactionFeeDistribution(t *testing.T) {
 			minerBalance:                 big.NewInt(0),
 			senderBalance:                big.NewInt(2000000000000000000), // 2 ETH
 			expectSuccess:                true,
-			experientialHardFork:         true,
+			prePrometheusHardFork:        true,
 			expectedMinerBalanceAfterTx:  big.NewInt(42000000000000),     // 0 + (21000 * 2000000000)
 			expectedSenderBalanceAfterTx: big.NewInt(999958000000000000), // 2 ETH - 1 ETH - 0.000042 ETH
 		},
 		{
-			name:                         "After Experimental - Gas refund scenario - partial gas usage",
+			name:                         "After PrePrometheus - Gas refund scenario - partial gas usage",
 			gasPrice:                     big.NewInt(1000000000), // 1 Gwei
 			gasLimit:                     50000,
 			gasUsed:                      21000,
@@ -99,7 +99,7 @@ func TestNormalTransactionFeeDistribution(t *testing.T) {
 			minerBalance:                 big.NewInt(0),
 			senderBalance:                big.NewInt(2000000000000000000), // 2 ETH
 			expectSuccess:                true,
-			experientialHardFork:         true,
+			prePrometheusHardFork:        true,
 			expectedMinerBalanceAfterTx:  big.NewInt(21000000000000),     // 0 + (21000 * 1 Gwei)
 			expectedSenderBalanceAfterTx: big.NewInt(999979000000000000), // 2 ETH - 1 ETH - 0.000021 ETH
 		},
@@ -113,12 +113,12 @@ func TestNormalTransactionFeeDistribution(t *testing.T) {
 			minerBalance:                 big.NewInt(0),
 			senderBalance:                big.NewInt(2000000000000000000), // 2 ETH
 			expectSuccess:                true,
-			experientialHardFork:         false,
+			prePrometheusHardFork:        false,
 			expectedMinerBalanceAfterTx:  big.NewInt(21000000000000),     // 0 + (21000 * 1 Gwei) - only actual gas used
 			expectedSenderBalanceAfterTx: big.NewInt(999979000000000000), // 2 ETH - 1 ETH - 0.000021 ETH (refund 29000 gas)
 		},
 		{
-			name:                         "After Experimental - Gas refund with high gas limit",
+			name:                         "After PrePrometheus - Gas refund with high gas limit",
 			gasPrice:                     VRC25GasPrice,                   // VRC25 gas price = 0.25 Gwei
 			gasLimit:                     100000,                          // Much higher limit
 			gasUsed:                      21000,                           // Only basic transfer gas used
@@ -126,7 +126,7 @@ func TestNormalTransactionFeeDistribution(t *testing.T) {
 			minerBalance:                 big.NewInt(0),                   // 1 ETH initial
 			senderBalance:                big.NewInt(2000000000000000000), // 2 ETH
 			expectSuccess:                true,
-			experientialHardFork:         true,
+			prePrometheusHardFork:        true,
 			expectedMinerBalanceAfterTx:  big.NewInt(5250000000000),      //  + (21000 * 250000000)
 			expectedSenderBalanceAfterTx: big.NewInt(999994750000000000), // 2 ETH - 1 ETH - 0.00000525 ETH (refund 79000 gas = 19750000000000 wei )
 		},
@@ -149,21 +149,21 @@ func TestNormalTransactionFeeDistribution(t *testing.T) {
 
 			// Create chain config
 			config := &params.ChainConfig{
-				ChainId:           big.NewInt(89),
-				HomesteadBlock:    big.NewInt(0),
-				EIP150Block:       big.NewInt(0),
-				EIP155Block:       big.NewInt(0),
-				EIP158Block:       big.NewInt(0),
-				ByzantiumBlock:    big.NewInt(0),
-				AtlasBlock:        big.NewInt(13523400),
-				ExperientialBlock: big.NewInt(13523410), // Fix refund issue at Atlas
+				ChainId:            big.NewInt(89),
+				HomesteadBlock:     big.NewInt(0),
+				EIP150Block:        big.NewInt(0),
+				EIP155Block:        big.NewInt(0),
+				EIP158Block:        big.NewInt(0),
+				ByzantiumBlock:     big.NewInt(0),
+				AtlasBlock:         big.NewInt(13523400),
+				PrePrometheusBlock: big.NewInt(13523410), // Fix refund issue at Atlas
 			}
 
 			var blockNumber *big.Int
-			if tt.experientialHardFork {
-				blockNumber = big.NewInt(13523411) // After Experiential
+			if tt.prePrometheusHardFork {
+				blockNumber = big.NewInt(13523411) // After PrePrometheus
 			} else {
-				blockNumber = big.NewInt(13523399) // Before Experiential
+				blockNumber = big.NewInt(13523399) // Before PrePrometheus
 			}
 
 			// Create EVM context
@@ -431,14 +431,14 @@ func TestVRC25TokenFeeDistribution(t *testing.T) {
 
 			// Create chain config
 			config := &params.ChainConfig{
-				ChainId:           big.NewInt(89),
-				HomesteadBlock:    big.NewInt(0),
-				EIP150Block:       big.NewInt(0),
-				EIP155Block:       big.NewInt(0),
-				EIP158Block:       big.NewInt(0),
-				ByzantiumBlock:    big.NewInt(0),
-				AtlasBlock:        big.NewInt(13523400), // VRC25 active after this block
-				ExperientialBlock: big.NewInt(13523410), // Fix refund issue at Atlas
+				ChainId:            big.NewInt(89),
+				HomesteadBlock:     big.NewInt(0),
+				EIP150Block:        big.NewInt(0),
+				EIP155Block:        big.NewInt(0),
+				EIP158Block:        big.NewInt(0),
+				ByzantiumBlock:     big.NewInt(0),
+				AtlasBlock:         big.NewInt(13523400), // VRC25 active after this block
+				PrePrometheusBlock: big.NewInt(13523410), // Fix refund issue at Atlas
 			}
 
 			// Create EVM context
@@ -448,7 +448,7 @@ func TestVRC25TokenFeeDistribution(t *testing.T) {
 				GetHash:     func(uint64) common.Hash { return common.Hash{} },
 				Origin:      sender,
 				Coinbase:    miner,
-				BlockNumber: big.NewInt(13523411), // After ExperientialBlock
+				BlockNumber: big.NewInt(13523411), // After PrePrometheusBlock
 				Time:        big.NewInt(0),
 				Difficulty:  big.NewInt(0),
 				GasLimit:    8000000,

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -345,7 +345,7 @@ func (st *StateTransition) refundGas(isUsedTokenFee bool) {
 		if isUsedTokenFee {
 			remaining := new(big.Int).Mul(new(big.Int).SetUint64(st.gas), common.TRC21GasPrice)
 			st.vrc25RefundGas(*st.msg.To(), remaining)
-		} else if st.evm.ChainConfig().IsExperiential(st.evm.BlockNumber) {
+		} else if st.evm.ChainConfig().IsPrePrometheus(st.evm.BlockNumber) {
 			from := st.from()
 			remaining := new(big.Int).Mul(new(big.Int).SetUint64(st.gas), st.gasPrice)
 			st.state.AddBalance(from.Address(), remaining)

--- a/params/config.go
+++ b/params/config.go
@@ -218,9 +218,9 @@ type ChainConfig struct {
 	TIPTomoXLendingBlock         *big.Int `json:"tipTomoXLendingBlock,omitempty"`         // TIPTomoXLending switch block (nil = no fork, 0 = already activated)
 	TIPTomoXCancellationFeeBlock *big.Int `json:"tipTomoXCancellationFeeBlock,omitempty"` // TIPTomoXCancellationFee switch block (nil = no fork, 0 = already activated)
 
-	SaigonBlock       *big.Int `json:"saigonBlock,omitempty"`       // Saigon switch block (nil = no fork, 0 = already activated)
-	AtlasBlock        *big.Int `json:"atlasBlock,omitempty"`        // Atlas switch block (nil = no fork, 0 = already activated)
-	ExperientialBlock *big.Int `json:"experientialBlock,omitempty"` // Experiential switch block (nil = no fork, 0 = already activated)
+	SaigonBlock        *big.Int `json:"saigonBlock,omitempty"`        // Saigon switch block (nil = no fork, 0 = already activated)
+	AtlasBlock         *big.Int `json:"atlasBlock,omitempty"`         // Atlas switch block (nil = no fork, 0 = already activated)
+	PrePrometheusBlock *big.Int `json:"prePrometheusBlock,omitempty"` // PrePrometheus switch block (nil = no fork, 0 = already activated)
 
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty"`
@@ -273,7 +273,7 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v TIP2019: %v TIPSigning: %v TIPRandomize: %v BlackListHF: %v TIPTRC21Fee: %v TIPTomoX: %v TIPTomoXLending: %v TIPTomoXCancellationFee: %v Saigon: %v Atlas: %v Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v TIP2019: %v TIPSigning: %v TIPRandomize: %v BlackListHF: %v TIPTRC21Fee: %v TIPTomoX: %v TIPTomoXLending: %v TIPTomoXCancellationFee: %v Saigon: %v Atlas: %v PrePrometheus: %v Engine: %v}",
 		c.ChainId,
 		c.HomesteadBlock,
 		c.EIP150Block,
@@ -290,6 +290,7 @@ func (c *ChainConfig) String() string {
 		c.TIPTomoXCancellationFeeBlock,
 		c.SaigonBlock,
 		c.AtlasBlock,
+		c.PrePrometheusBlock,
 		engine,
 	)
 }
@@ -371,8 +372,8 @@ func (c *ChainConfig) IsAtlas(num *big.Int) bool {
 	return isForked(c.AtlasBlock, num)
 }
 
-func (c *ChainConfig) IsExperiential(num *big.Int) bool {
-	return isForked(c.ExperientialBlock, num)
+func (c *ChainConfig) IsPrePrometheus(num *big.Int) bool {
+	return isForked(c.PrePrometheusBlock, num)
 }
 
 /* Feature flag check */
@@ -485,6 +486,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.AtlasBlock, newcfg.AtlasBlock, head) {
 		return newCompatError("Atlas fork block", c.AtlasBlock, newcfg.AtlasBlock)
 	}
+	if isForkIncompatible(c.PrePrometheusBlock, newcfg.PrePrometheusBlock, head) {
+		return newCompatError("PrePrometheus fork block", c.PrePrometheusBlock, newcfg.PrePrometheusBlock)
+	}
 	return nil
 }
 
@@ -555,7 +559,7 @@ type Rules struct {
 	IsTIP2019, IsTIPSigning, IsTIPRandomize                  bool
 	IsBlackListHF, IsTIPTRC21Fee                             bool
 	IsTIPTomoX, IsTIPTomoXLending, IsTIPTomoXCancellationFee bool
-	IsSaigon, IsAtlas                                        bool
+	IsSaigon, IsAtlas, IsPrePrometheus                       bool
 }
 
 func (c *ChainConfig) Rules(num *big.Int) Rules {
@@ -584,5 +588,6 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsTIPTomoXCancellationFee: c.IsTIPTomoXCancellationFee(num),
 		IsSaigon:                  c.IsSaigon(num),
 		IsAtlas:                   c.IsAtlas(num),
+		IsPrePrometheus:           c.IsPrePrometheus(num),
 	}
 }

--- a/params/config.go
+++ b/params/config.go
@@ -33,15 +33,16 @@ var (
 var (
 	// VicMainnetChainConfig contains the chain parameters to run a Viction node on the main network.
 	VicMainnetChainConfig = &ChainConfig{
-		ChainId:        big.NewInt(88),
-		HomesteadBlock: big.NewInt(1),
-		EIP150Block:    big.NewInt(2),
-		EIP150Hash:     common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
-		EIP155Block:    big.NewInt(3),
-		EIP158Block:    big.NewInt(3),
-		ByzantiumBlock: big.NewInt(4),
-		SaigonBlock:    big.NewInt(86158494),
-		AtlasBlock:     big.NewInt(97705094),
+		ChainId:            big.NewInt(88),
+		HomesteadBlock:     big.NewInt(1),
+		EIP150Block:        big.NewInt(2),
+		EIP150Hash:         common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+		EIP155Block:        big.NewInt(3),
+		EIP158Block:        big.NewInt(3),
+		ByzantiumBlock:     big.NewInt(4),
+		SaigonBlock:        big.NewInt(86158494),
+		AtlasBlock:         big.NewInt(97705094),
+		PrePrometheusBlock: big.NewInt(110712671),
 		Posv: &PosvConfig{
 			Period:              2,
 			Epoch:               900,
@@ -71,6 +72,7 @@ var (
 		TIPTomoXCancellationFeeBlock: big.NewInt(0),
 		SaigonBlock:                  big.NewInt(10004200),
 		AtlasBlock:                   big.NewInt(24697500),
+		PrePrometheusBlock:           big.NewInt(36911450),
 		Posv: &PosvConfig{
 			Period:              2,
 			Epoch:               900,


### PR DESCRIPTION
Hard fork Pre-Prometheus will be activated on Mainnet at block 110,712,671 (June 30, 2026) and on Testnet at block 36,911,450 (May 26, 2026).